### PR TITLE
Added setter to save state for "post" computed property

### DIFF
--- a/@factor/@core/post/dashboard-edit.vue
+++ b/@factor/@core/post/dashboard-edit.vue
@@ -10,8 +10,13 @@
 <script>
 export default {
   computed: {
-    post() {
-      return this.$store.val(this._id) || {}
+    post: {
+      get() {
+        return this.$store.val(this._id) || {}
+      },
+      set(v) {
+        this.$store.add(this._id, v)
+      }
     },
     _id() {
       return this.$route.query._id || ""
@@ -64,4 +69,3 @@ export default {
   }
 }
 </script>
- 


### PR DESCRIPTION
Bugfix: post computed property was missing a setter function which caused an error when selecting a page template