### PR TITLE
feat(docker-compose): Docker and docker-compose support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.DS_Store
+.dockerignore
+.env.example
+.git
+.gitignore
+.nvmrc
+docker-compose.yaml
+Dockerfile
+node_modules
+npm-debug.log
+package-lock.json
+yarn.lock
+yarn-error.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:12.14.1-buster-slim
+
+RUN apt-get update && apt-get -y install --no-install-recommends \
+unzip \
+bzip2 && \
+apt-get -y autoremove && \
+apt-get clean && \
+rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN mkdir -p /var/factor
+WORKDIR /var/factor
+
+COPY . .
+
+RUN yarn install
+
+EXPOSE 3000
+
+RUN chown -R node /var/factor
+USER node
+CMD ["yarn", "factor", "dev"]

--- a/dev/mongodb-init.js
+++ b/dev/mongodb-init.js
@@ -1,0 +1,12 @@
+/* eslint-disable */
+
+db = db.getSiblingDB('factor');
+
+db.createUser({
+  user: 'factor',
+  pwd: 'factorDEV',
+  roles: [{
+    role: 'readWrite',
+    db: 'factor',
+  }],
+});

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,29 @@
+version: '3.7'
+volumes:
+  mongo_data: {}
+services:
+  mongodb:
+    image: mongo:4.2.3
+    restart: always
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo_data:/data/db
+      - ./dev/mongodb-init.js:/docker-entrypoint-initdb.d/mongodb-init.js
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=root
+      - MONGO_INITDB_ROOT_PASSWORD=mongodbROOT
+      - MONGO_INITDB_DATABASE=factor
+  factor:
+    build:
+      context: .
+    image: factor:dev
+    working_dir: "/var/factor"
+    dns:
+      - 1.1.1.1
+      - 8.8.8.8
+    volumes:
+      - .:/var/factor
+      - /var/factor/node_modules/
+    ports:
+      - "3000:3000"


### PR DESCRIPTION
This PR provides Docker and `docker-compose` support. It requires updating getting started documentation, etc.

To build the Docker container locally based off your local filesystem, simply run `docker-compose build`. This tags the Docker container as `factor:dev`.

Once you've built the Docker container, run `docker-compose up`.

When you edit, create, delete files locally the changes will automatically be synced into the Docker container.

Keep in mind, you should modify files locally, but should be running the application (e.g. yarn factor dev) from inside of the Docker container not locally.

Docker Compose will run a local MongoDB instance which can be accessed at:

```
Server: mongodb
Username: factor
Password: factorDEV
Database: factor
```

The `.env` file key `DB_CONNECTION` will need to be updated to something like:

```
DB_CONNECTION=mongodb+srv://factor:factorDEV@mongodb/factor?retryWrites=true&w=majority
```

Docker Compose does not manage the `.env` file at all. Changes to `.env` will synced into the container from the local filesystem.