### PR TITLE
feat(api): add offEvent

### DIFF
--- a/@factor/api/events.ts
+++ b/@factor/api/events.ts
@@ -9,3 +9,7 @@ export const emitEvent = (event: string, ...data: unknown[]): void => {
 export const onEvent = (event: string, callback: Function): void => {
   __events.$on(event, callback)
 }
+
+export const offEvent = (event: string, callback: Function): void => {
+  __events.$off(event, callback)
+}


### PR DESCRIPTION
Currently you can only register event. This forces you to register all events at app level.
If you register event on `mounted` - when component is destroyed - handler will still remain, which is memory leak + might cause some interesting issues (you operate on destroyed component).

It's small Feature / Bugfix
