### PR TITLE
Fixes for template settings and sortable

### DIFF
--- a/@factor/templates/index.ts
+++ b/@factor/templates/index.ts
@@ -28,7 +28,7 @@ export const getTemplateFields = async (
   const theComponent = await tpl.component()
   const {
     default: {
-      options: { templateSettings },
+      templateSettings
     },
   } = theComponent
 
@@ -111,8 +111,8 @@ export const getDefaultTemplateSettings = (
       out[_id] = val
     }
 
-    return out
   })
+  return out
 }
 
 export const setup = (): void => {

--- a/@factor/ui/form/sortable.vue
+++ b/@factor/ui/form/sortable.vue
@@ -117,23 +117,31 @@ export default {
     },
     addItem(this: any) {
       const newLocalValue = this.localValue.slice()
-
-      newLocalValue.push({
-        __title: `Item ${this.value.length + 1}`,
+      const selected = this.value.length
+      let item = {
+        __title: `Item ${selected + 1}`,
         __key: randomToken(4),
-      })
+      }
 
+      this.settings.forEach(field => {
+        if ('_default' in field) {
+          item[field._id] = field._default
+        }
+      });
+      newLocalValue.push(item)
+      
       this.localValue = newLocalValue
+      this.selected = selected
     },
     removeItem(this: any, index: number) {
       const newLocalValue = this.localValue.slice()
 
-      newLocalValue.splice(index)
+      newLocalValue.splice(index, 1)
 
       this.localValue = newLocalValue
 
       if (index == this.selected) {
-        this.selected = 0
+        this.selected = index > 0 ? index - 1 : 0
       }
     },
     getValue(this: any, _id: string) {


### PR DESCRIPTION
There are currently no contribution guidelines: https://factor.dev/docs/contribution. But here a pull request with some fixes. Please describe your change...

## Template Settings

- The settings could not be loaded due to a wrong destructering.
- Default values were not applied because the return was in the wrong bracket.

## Sortable

- When adding now an item, the default values from the settings are applied. In addition,  the created item get selected, which is more intuitiv as mostly you want to edit the item rightaway.
- Now only the selected item gets removed. Before all suceeding items were deleted. After deletion, the previous item gets selected instead of the first, which is in my opinion also more logical.
