### PR TITLE
added arguments to package-webpack-config filter

### DIFF
--- a/@factor/build/webpack-config.ts
+++ b/@factor/build/webpack-config.ts
@@ -286,7 +286,7 @@ export const getWebpackConfig = async (
     plugins.push(new BundleAnalyzer.BundleAnalyzerPlugin({ generateStatsFile: true }))
   }
 
-  const packageConfig = applyFilters("package-webpack-config", {})
+  const packageConfig = applyFilters("package-webpack-config", {}, _arguments)
 
   const config = merge(
     baseConfig,


### PR DESCRIPTION
### Please describe your change...

Adds missing _arguments to package-webpack-config filter, which allows to apply webpack configs depending on the target (server or client). This is meant to allow server/client-specific webpack optimizations.
