### PR TITLE
feat(posts): enable sub-routing through permalinks

### DIFF
--- a/@factor/api/utils.ts
+++ b/@factor/api/utils.ts
@@ -279,7 +279,7 @@ export const slugify = (text?: string): string | undefined => {
     .toString()
     .toLowerCase()
     .replace(/\s+/g, "-") // Replace spaces with -
-    .replace(/[^\w-]+/g, "") // Remove all non-word chars
+    .replace(/[^\w/-]+/g, "") // Remove all non-word chars except /
     .replace(/^\d+/g, "") // Remove Numbers
     .replace(/--+/g, "-") // Replace multiple - with single -
     .replace(/^-+/, "") // Trim - from start of text

--- a/@factor/templates/index.ts
+++ b/@factor/templates/index.ts
@@ -173,7 +173,7 @@ export const setup = (): void => {
     key: "runTemplatePermalink",
     hook: "content-routes-unmatched",
     callback: (_: RouteConfig[]) => {
-      _.unshift({ path: "/:permalink", component: () => import("./template.vue") })
+      _.unshift({ path: "/:permalink*", component: () => import("./template.vue") })
 
       return _
     },


### PR DESCRIPTION
This PR enables page subrouting eg:

/company => page with permalink "company"
/company/subpage => page with permalink "company/subpage"

"slugify" is now allowing "/" characters.... should be now problem 
