### PR TITLE
fix(actions): replace deprecated ::set-output with GITHUB_OUTPUT

### DIFF
--- a/.ref/@kaption/workflows/deploy-kaption.yml
+++ b/.ref/@kaption/workflows/deploy-kaption.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Get pnpm store directory
         id: pnpm-cache
         run: |
-          echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
+          echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         name: Setup pnpm cache

--- a/.ref/@kaption/workflows/health.yml
+++ b/.ref/@kaption/workflows/health.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Get pnpm store directory
         id: pnpm-cache
         run: |
-          echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
+          echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         name: Setup pnpm cache

--- a/.ref/release.yml
+++ b/.ref/release.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Get pnpm store directory
         id: pnpm-cache
         run: |
-          echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
+          echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - name: Install Deps
         run: pnpm -v && pnpm i && pnpm rebuild --recursive


### PR DESCRIPTION
Replace deprecated 'echo "::set-output name=...::..."' syntax with the modern '$GITHUB_OUTPUT' environment file approach in GitHub Actions workflow files.

The ::set-output syntax was deprecated in GitHub Actions (https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).

## Changes
- .ref/release.yml: update pnpm cache directory step
- .ref/@kaption/workflows/health.yml: update pnpm cache directory step
- .ref/@kaption/workflows/deploy-kaption.yml: update pnpm cache directory step

Each change replaces:
```yaml
run: echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
```
with:
```yaml
run: echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
```